### PR TITLE
Cambio en la estructura del geo

### DIFF
--- a/resources/happinesses/config.json
+++ b/resources/happinesses/config.json
@@ -25,13 +25,13 @@
 			"id": "message",
 			"order": 2
 		},
-		"latlng": {
-			"name": "latlng",
-			"type": "object",
-			"typeLabel": "object",
-			"id": "latlng",
+		"loc": {
+			"name": "loc",
+			"type": "array",
+			"typeLabel": "array",
+			"id": "loc",
 			"order": 3,
-			"required": false
+			"required": true
 		},
 		"city": {
 			"name": "city",


### PR DESCRIPTION
Se modificó la estructura de la localización geográfica. Ahora es un array de la forma [longitud, latitud]. Este es el formato que acepta MongoDB para los geo.
